### PR TITLE
Fix colors in Termite

### DIFF
--- a/themes/Relaxed
+++ b/themes/Relaxed
@@ -1,7 +1,7 @@
 [colors]
-background = "#353a44"
-cursor = "#d9d9d9"
-foreground = "#d9d9d9"
+background = #353a44
+cursor = #d9d9d9
+foreground = #d9d9d9
 color0 = #151515
 color1 = #bc5653
 color2 = #909d63


### PR DESCRIPTION
Removed quotes around colors for the background and foreground as it just made the background black and foreground white instead of using the proper colors.